### PR TITLE
feat: validate custom vault addresses against allowlist

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.x"
+          go-version: "1.24"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v7
@@ -47,6 +47,7 @@ jobs:
           VAULT_DEV_ROOT_TOKEN_ID: testtoken
           VAULT_DEV_LISTEN_ADDRESS: 0.0.0.0:8200
           VAULT_LOG_LEVEL: trace
+          SKIP_SETCAP: "true"
 
     steps:
       - id: go-cache-paths
@@ -60,7 +61,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.x"
+          go-version: "1.24"
 
       - name: Go Build Cache
         uses: actions/cache@v4
@@ -73,6 +74,30 @@ jobs:
         with:
           path: ${{ steps.go-cache-paths.outputs.go-mod }}
           key: ${{ runner.os }}-go-mod-${{ hashFiles('**/go.sum') }}
+
+      - name: Diagnose Vault service container
+        run: |
+          echo "--- docker ps -a ---"
+          docker ps -a || true
+          for cid in $(docker ps -a -q); do
+            name=$(docker inspect --format '{{.Name}} {{.Config.Image}}' "$cid")
+            echo "--- docker logs $cid ($name) ---"
+            docker logs "$cid" 2>&1 | tail -50 || true
+          done
+          echo "--- curl health ---"
+          curl -v http://127.0.0.1:8200/v1/sys/health || true
+
+      - name: Wait for Vault to be ready
+        run: |
+          for i in {1..60}; do
+            if curl -fsS http://127.0.0.1:8200/v1/sys/health >/dev/null 2>&1; then
+              echo "vault is ready after ${i}s"
+              exit 0
+            fi
+            sleep 1
+          done
+          echo "vault did not become ready in time" >&2
+          exit 1
 
       - name: Run tests
         run: make test

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -49,6 +49,11 @@ linters:
       - common-false-positives
       - legacy
       - std-error-handling
+    rules:
+      - path: _test\.go
+        linters:
+          - gosec
+        text: "G101"
     paths:
       - third_party$
       - builtin$

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -114,6 +114,7 @@ var _ = BeforeSuite(func() {
 	})
 	Expect(err).ToNot(HaveOccurred())
 
+	Expect(os.Setenv("ALLOWED_VAULT_ADDRS", "http://localhost:8200")).To(Succeed())
 	appConfig, err := vault.NewAppConfig()
 	Expect(err).ToNot(HaveOccurred())
 

--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"reflect"
 	"strings"
 	"sync"
@@ -289,6 +290,10 @@ func (r *VaultSecretReconciler) validateResource(vaultSecret *k8skiwicomv1.Vault
 		vaultSecret.Spec.Addr = r.VaultConfig.DefaultVaultAddr
 	}
 
+	if err = validateVaultAddr(vaultSecret.Spec.Addr, r.VaultConfig.AllowedVaultAddrs, r.VaultConfig.DefaultVaultAddr); err != nil {
+		return err
+	}
+
 	if vaultSecret.Spec.Auth.Token != "" {
 		return nil
 	}
@@ -329,6 +334,34 @@ func updateVaultSecretResource(ctx context.Context, c client.Client, secret *k8s
 	err := c.Status().Update(ctx, secret)
 	if err != nil {
 		return fmt.Errorf("failed to update resource status: %w", err)
+	}
+
+	return nil
+}
+
+func validateVaultAddr(addr string, allowedAddrsStr string, defaultAddr string) error {
+	if addr == defaultAddr {
+		return nil
+	}
+
+	u, err := url.Parse(addr)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return errors.New("invalid or empty vault address")
+	}
+
+	if allowedAddrsStr != "" {
+		allowed := false
+		for _, a := range strings.Split(allowedAddrsStr, ",") {
+			if strings.TrimSpace(a) == addr {
+				allowed = true
+				break
+			}
+		}
+		if !allowed {
+			return fmt.Errorf("vault address %q is not in the allowlist", addr)
+		}
+	} else {
+		return errors.New("custom vault addresses are not permitted (allowlist is empty)")
 	}
 
 	return nil

--- a/controllers/vaultsecret_controller_test.go
+++ b/controllers/vaultsecret_controller_test.go
@@ -1,0 +1,82 @@
+package controllers
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateVaultAddr(t *testing.T) {
+	const defaultAddr = "https://vault.default.example.com"
+
+	tests := []struct {
+		name       string
+		addr       string
+		allowed    string
+		wantErrSub string
+	}{
+		{
+			name: "matches default addr",
+			addr: defaultAddr,
+		},
+		{
+			name:       "empty addr",
+			addr:       "",
+			wantErrSub: "invalid or empty vault address",
+		},
+		{
+			name:       "malformed url",
+			addr:       "::not a url::",
+			wantErrSub: "invalid or empty vault address",
+		},
+		{
+			name:       "missing scheme",
+			addr:       "vault.example.com",
+			wantErrSub: "invalid or empty vault address",
+		},
+		{
+			name:       "custom addr rejected when allowlist empty",
+			addr:       "https://vault.other.example.com",
+			wantErrSub: "allowlist is empty",
+		},
+		{
+			name:       "addr not in allowlist",
+			addr:       "https://vault.other.example.com",
+			allowed:    "https://vault.allowed.example.com",
+			wantErrSub: "is not in the allowlist",
+		},
+		{
+			name:    "addr in single-entry allowlist",
+			addr:    "https://vault.allowed.example.com",
+			allowed: "https://vault.allowed.example.com",
+		},
+		{
+			name:    "addr in multi-entry allowlist with whitespace",
+			addr:    "https://vault.b.example.com",
+			allowed: "https://vault.a.example.com, https://vault.b.example.com ,https://vault.c.example.com",
+		},
+		{
+			name:       "case-sensitive allowlist mismatch",
+			addr:       "https://Vault.Allowed.Example.Com",
+			allowed:    "https://vault.allowed.example.com",
+			wantErrSub: "is not in the allowlist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateVaultAddr(tt.addr, tt.allowed, defaultAddr)
+			if tt.wantErrSub == "" {
+				if err != nil {
+					t.Fatalf("expected no error, got %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, got nil", tt.wantErrSub)
+			}
+			if !strings.Contains(err.Error(), tt.wantErrSub) {
+				t.Fatalf("expected error containing %q, got %q", tt.wantErrSub, err.Error())
+			}
+		})
+	}
+}

--- a/pkg/vault/config.go
+++ b/pkg/vault/config.go
@@ -24,6 +24,7 @@ type AppConfig struct {
 	OperatorRole            string        `koanf:"operator_role"`
 	Role                    string        `koanf:"role"`
 	DefaultVaultAddr        string        `koanf:"vault_addr"`
+	AllowedVaultAddrs       string        `koanf:"allowed_vault_addrs"`
 	VaultUIAddr             string        `koanf:"vault_ui_addr"`
 	MaxConcurrentReconciles int           `koanf:"max_concurrent_reconciles"`
 	RefreshTokenBefore      time.Duration `koanf:"refresh_token_before"`


### PR DESCRIPTION
Require the per-resource Vault addresses to appear in the new AllowedVaultAddrs config (comma-separated).