### PR TITLE
fix: make auth SA cache key injective to prevent cross-tenant disclosure

### DIFF
--- a/controllers/vaultsecret_controller.go
+++ b/controllers/vaultsecret_controller.go
@@ -18,6 +18,8 @@ package controllers
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/rand/v2"
@@ -231,9 +233,27 @@ func (r *VaultSecretReconciler) cachedSA(id string) *vault.AuthServiceAccount {
 	return r.authSACache[id]
 }
 
+// authSACacheKey builds an injective cache key from the fields that identify an
+// AuthServiceAccount. A plain "-"-joined string is NOT injective: "-" is legal in
+// namespace names, ServiceAccount names, roles, and auth paths, so distinct tuples
+// such as (ns="team-a", sa="svc") and (ns="team", sa="a-svc") collapse to the same
+// key. That collision lets one tenant's reconcile ride on another tenant's cached
+// identity and mint a Kubernetes SA-JWT for it, disclosing the other tenant's Vault
+// secrets. We hash the length-prefixed fields so the encoding is unambiguous
+// regardless of which characters the individual fields contain.
+func authSACacheKey(addr, namespace, saName, role, authPath string) string {
+	h := sha256.New()
+	for _, field := range []string{addr, namespace, saName, role, authPath} {
+		// Length prefix makes the concatenation injective: no field value can
+		// spill across the boundary into the next field.
+		_, _ = fmt.Fprintf(h, "%d:%s", len(field), field)
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
 func (r *VaultSecretReconciler) getAuthServiceAccount(vaultSecret k8skiwicomv1.VaultSecret) (*vault.AuthServiceAccount, error) {
 	saRef := vaultSecret.Spec.Auth.ServiceAccountRef
-	id := fmt.Sprintf("%s-%s-%s-%s-%s", vaultSecret.Spec.Addr, vaultSecret.Namespace, saRef.Name, saRef.Role, saRef.AuthPath)
+	id := authSACacheKey(vaultSecret.Spec.Addr, vaultSecret.Namespace, saRef.Name, saRef.Role, saRef.AuthPath)
 	saAccount := r.cachedSA(id)
 	if saAccount != nil {
 		return saAccount, nil
@@ -345,7 +365,9 @@ func withJitter(d time.Duration) time.Duration {
 	if d <= 0 {
 		return d
 	}
-	return d + time.Duration(rand.N(int64(d/10)))
+	// Jitter only spreads reconcile load across time; it is not security-sensitive,
+	// so a non-cryptographic RNG is fine.
+	return d + time.Duration(rand.N(int64(d/10))) //nolint:gosec // G404: weak RNG acceptable for load jitter
 }
 
 func validateVaultAddr(addr string, allowedAddrsStr string, defaultAddr string) error {

--- a/controllers/vaultsecret_controller_test.go
+++ b/controllers/vaultsecret_controller_test.go
@@ -80,3 +80,44 @@ func TestValidateVaultAddr(t *testing.T) {
 		})
 	}
 }
+
+// TestAuthSACacheKeyInjective guards against the cross-tenant secret disclosure
+// caused by a non-injective cache key. Two tenants whose ("-"-joined) tuples
+// collapse to the same string must still receive distinct cache keys, otherwise
+// one tenant's reconcile can ride on the other's cached identity.
+func TestAuthSACacheKeyInjective(t *testing.T) {
+	const addr = "http://vault.vault.svc.cluster.local:8200"
+	const role = "reader-prod"
+	const authPath = "auth/kubernetes/login"
+
+	// (namespace="team-a", saName="svc") vs (namespace="team", saName="a-svc")
+	// both "-"-join to "...-team-a-svc-...".
+	keyA := authSACacheKey(addr, "team-a", "svc", role, authPath)
+	keyB := authSACacheKey(addr, "team", "a-svc", role, authPath)
+
+	if keyA == keyB {
+		t.Fatalf("cache key collision between distinct tenants: %q == %q", keyA, keyB)
+	}
+
+	// Same tuple must be stable (so caching actually works).
+	if got := authSACacheKey(addr, "team-a", "svc", role, authPath); got != keyA {
+		t.Fatalf("cache key not stable for identical input: %q != %q", got, keyA)
+	}
+
+	// A field boundary shift in any position must change the key.
+	tuples := [][5]string{
+		{addr, "ns", "sa", "role", "path"},
+		{addr, "n", "ssa", "role", "path"},
+		{addr, "ns", "sa", "rol", "epath"},
+		{"http://a", "b", "sa", "role", "path"},
+		{"http://ab", "", "sa", "role", "path"},
+	}
+	seen := map[string][5]string{}
+	for _, tp := range tuples {
+		k := authSACacheKey(tp[0], tp[1], tp[2], tp[3], tp[4])
+		if prev, ok := seen[k]; ok {
+			t.Fatalf("cache key collision: %v and %v both map to %q", prev, tp, k)
+		}
+		seen[k] = tp
+	}
+}


### PR DESCRIPTION
The authSACache key was built by '-'-joining (addr, namespace, saName, role, authPath). Since '-' is legal in K8s namespaces, ServiceAccount names, roles, and Vault auth paths, the mapping was not injective: e.g. (ns=team-a, sa=svc) and (ns=team, sa=a-svc) produced the same key. A cache hit then returned another tenant's cached AuthServiceAccount, minting that tenant's SA-JWT and silently disclosing its Vault secrets into the colliding tenant's namespace.

Hash the length-prefixed fields with SHA-256 so the key is injective by construction regardless of field contents. Add a regression test.